### PR TITLE
Bug fix, EventEmitter.Once doesn't work and will panic

### DIFF
--- a/event_emitter.go
+++ b/event_emitter.go
@@ -22,15 +22,17 @@ func (ee *EventEmitter) Emit(event string, args ...interface{}) {
 		return
 	}
 
-	for idx := range listeners {
+	for idx := 0; idx < len(listeners); idx++ {
 		if listeners[idx].fn != nil {
 			listeners[idx].fn(args...)
 		}
 
 		if listeners[idx].once {
 			listeners = append(listeners[:idx], listeners[idx+1:]...)
+			idx--
 		}
 	}
+	ee.listeners[event] = listeners
 }
 
 func (ee *EventEmitter) On(event string, fn func(...interface{})) {

--- a/event_emitter_test.go
+++ b/event_emitter_test.go
@@ -63,6 +63,51 @@ func Test_EventEmitter_On(t *testing.T) {
 	}
 }
 
+func Test_EventEmitter_Once(t *testing.T) {
+	rand.Seed(time.Now().UnixNano())
+
+	ee := NewEventEmitter()
+
+	eventX := "x only"
+	eventY := "y only"
+
+	var x, y int
+
+	ee.Once(eventX, func(args ...interface{}) {
+		x++
+	})
+
+	ee.Once(eventY, func(args ...interface{}) {
+		y++
+	})
+
+	ee.On(eventY, func(args ...interface{}) {
+		y++
+	})
+
+	ee.Emit(eventX)
+
+	if x != 1 {
+		t.Error("listener function not called")
+	}
+
+	if y != 0 {
+		t.Error("listener function incorrectly called")
+	}
+
+	ee.Emit(eventY)
+	ee.Emit(eventY)
+	ee.Emit(eventY)
+
+	if x != 1 {
+		t.Error("listener function incorrectly called")
+	}
+
+	if y != 4 {
+		t.Error("listener function incorrectly called")
+	}
+}
+
 func Benchmark_EventEmitter(b *testing.B) {
 	rand.Seed(time.Now().UnixNano())
 


### PR DESCRIPTION
There are two simple mistakes,

1. in the original code, `EventEmitter.Once` doesn't work as expected,
2. the original loop will panic about index out of bound.