### PR TITLE
Allow subscriptions to ignore particular entities

### DIFF
--- a/subscription.go
+++ b/subscription.go
@@ -15,6 +15,7 @@ func NewSubscription(cf *ComponentFilter) *Subscription {
 		Filter:    cf,
 		entityMap: make(entityMap),
 		entities:  make([]EID, 0),
+		ignoredEntities: make(entityMap),
 	}
 }
 
@@ -24,6 +25,7 @@ type Subscription struct {
 	entityMap       // we use (abuse) the lookup ability of maps for adding/removing EIDs
 	entities  []EID // we sort the map keys when GetEntities is called, only if dirty==true
 	dirty     bool
+	ignoredEntities entityMap
 	mutex     sync.Mutex
 }
 
@@ -68,4 +70,16 @@ func (s *Subscription) rebuildCache() {
 	sort.Slice(s.entities, func(i, j int) bool {
 		return s.entities[i] < s.entities[j]
 	})
+}
+
+func (s *Subscription) IgnoreEntity(id EID) {
+	s.mutex.Lock()
+	s.ignoredEntities[id] = &empty{}
+	s.RemoveEntity(id)
+	s.mutex.Unlock()
+}
+
+func (s *Subscription) EntityIsIgnored(id EID) bool {
+	_, ok := s.ignoredEntities[id]
+	return ok
 }

--- a/world.go
+++ b/world.go
@@ -321,15 +321,15 @@ func (w *World) updateSubscriptions(id EID) {
 
 	cf := cfInterface.(*bitset.BitSet)
 
-	for idx := range w.Subscriptions {
-		w.Subscriptions[idx].mutex.Lock()
+	for _, subscription := range w.Subscriptions {
+		subscription.mutex.Lock()
 
-		if w.Subscriptions[idx].Filter.Allow(cf) {
-			w.Subscriptions[idx].AddEntity(id)
+		if subscription.Filter.Allow(cf) && !subscription.EntityIsIgnored(id) {
+			subscription.AddEntity(id)
 		} else {
-			w.Subscriptions[idx].RemoveEntity(id)
+			subscription.RemoveEntity(id)
 		}
 
-		w.Subscriptions[idx].mutex.Unlock()
+		subscription.mutex.Unlock()
 	}
 }

--- a/world_test.go
+++ b/world_test.go
@@ -92,6 +92,29 @@ func TestWorld_RemoveEntity(t *testing.T) {
 			_, found = w.ComponentFlags.Load(e)
 			So(found, ShouldBeFalse)
 		})
+
+		Convey("Entities that are ignored by a subscription are not returned by the subscription", func() {
+			cid := w.RegisterComponent(&testComponent{})
+			testComponentFactory := &testComponentFactory{ComponentFactory: w.GetComponentFactory(cid)}
+
+			sub := w.AddSubscription(w.NewComponentFilter().Require(&testComponent{}).Build())
+
+			e := w.NewEntity()
+			testComponentFactory.Add(e)
+
+			So(len(sub.GetEntities()), ShouldEqual, 1)
+
+			_, found := w.ComponentFlags.Load(e)
+			So(found, ShouldBeTrue)
+
+			So(sub.EntityIsIgnored(e), ShouldBeFalse)
+
+			sub.IgnoreEntity(e)
+
+			So(len(sub.GetEntities()), ShouldEqual, 0)
+
+			So(sub.EntityIsIgnored(e), ShouldBeTrue)
+		})
 	})
 }
 


### PR DESCRIPTION
Adds `Subscription.IgnoreEntity()` which will prevent entities from appearing in the slice returned by `subscription.GetEntities()`