### PR TITLE
Use nextFactoryID for component registration

### DIFF
--- a/world.go
+++ b/world.go
@@ -89,7 +89,7 @@ func (w *World) RegisterComponent(c Component) ComponentID {
 		return id
 	}
 
-	nextId := atomic.AddUint64(w.nextEntityID, 1)
+	nextId := atomic.AddUint64(w.nextFactoryID, 1)
 	factory := newComponentFactory(ComponentID(nextId))
 	factory.world = w
 


### PR DESCRIPTION
A minor bug. Seems like components and entities share the same ID "space" and  nextFactoryID seems to be unused.  Probably not a big issue unless there are a large amount of entities and components.
